### PR TITLE
Update README to include XML dep.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ def deps do
     {:ex_aws_sqs, "~> 2.0"},
     {:poison, "~> 3.0"},
     {:hackney, "~> 1.9"},
+    {:sweet_xml, "~> 0.6"},
   ]
 end
 ```


### PR DESCRIPTION
Adding `sweet_xml` to the dependencies list in the README.md. SQS
response from AWS are only availble as XML. So an xml library is
required for `ex_aws_sqs` to function properly.