### PR TITLE
prepending queue to path

### DIFF
--- a/lib/ex_aws/sqs.ex
+++ b/lib/ex_aws/sqs.ex
@@ -277,7 +277,7 @@ defmodule ExAws.SQS do
     action_string = action |> Atom.to_string |> Macro.camelize
 
     %ExAws.Operation.Query{
-      path: "/" <> queue,
+      path: "/queue/#{queue}",
       params: params |> Map.put("Action", action_string),
       service: :sqs,
       action: action,


### PR DESCRIPTION
Testing ex_aws_sqs against localstack I'm getting this error:

```elixir
{:error,
  {
    :http_error,
    400,
    %{code: "Invalid request: MissingQueryParamRejection(QueueName), MissingQueryParamRejection(QueueUrl)",
    detail: "",
    message: "Invalid request: MissingQueryParamRejection(QueueName), MissingQueryParamRejection(QueueUrl); see the SQS docs.",
    request_id: "00000000-0000-0000-0000-000000000000", type: "Sender"}
  }
}
```

prepending "queue" to `path` parameter of the sqs query fix the problem