### PR TITLE
Use QueueUrl instead of QueueName for making requests to SQS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: elixir
+elixir: 1.5
+otp_release:
+  - 19.2
+
+services:
+  - docker
+
+before_install:
+  - docker run -d -p 9324:9324 softwaremill/elasticmq

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,10 +21,6 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+# Import environment specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :ex_aws,
+  debug_requests: true

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,9 @@
+use Mix.Config
+
+config :ex_aws, :sqs,
+  access_key_id: "foo",
+  secret_access_key: "bar",
+  scheme: "http://",
+  host: "localhost",
+  port: 9324,
+  region: "us-east-1"

--- a/test/lib/sqs/integration_test.exs
+++ b/test/lib/sqs/integration_test.exs
@@ -13,11 +13,12 @@ defmodule ExAws.SQSIntegrationTest do
   end
 
   test "add_permission/2" do
-    assert {:ok, _} = SQS.add_permission(@queue_name, "TestAddPermission") |> ExAws.request()
+    assert {:ok, %{body: _}} =
+             SQS.add_permission(@queue_name, "TestAddPermission") |> ExAws.request()
   end
 
   test "add_permission/3" do
-    assert {:ok, _} =
+    assert {:ok, %{body: _}} =
              SQS.add_permission(@queue_name, "TestAddPermission2", %{
                "681962096817" => :all,
                "071669896281" => [:send_message, :receive_message]
@@ -33,7 +34,7 @@ defmodule ExAws.SQSIntegrationTest do
 
     receipt_handle = List.first(messages).receipt_handle
 
-    assert {:ok, _} =
+    assert {:ok, %{body: %{request_id: _}}} =
              SQS.change_message_visibility(context.queue_url, receipt_handle, 300)
              |> ExAws.request()
   end
@@ -82,29 +83,35 @@ defmodule ExAws.SQSIntegrationTest do
         }
       end)
 
-    assert {:ok, _} =
+    assert {:ok, %{body: %{request_id: _, successes: successes}}} =
              SQS.change_message_visibility_batch(context.queue_url, messages_payload)
              |> ExAws.request()
+
+    assert successes |> Enum.sort() == Enum.map(messages, & &1.message_id) |> Enum.sort()
   end
 
   test "create_queue/1" do
-    assert {:ok, %{body: %{queue_url: _}}} =
-             SQS.create_queue("yet_another_test_queue") |> ExAws.request()
+    queue_name = "test_queue_2"
+
+    assert {:ok, %{body: %{queue_url: queue_url}}} =
+             SQS.create_queue(queue_name) |> ExAws.request()
+
+    assert queue_url |> String.contains?(queue_name)
   end
 
   test "create_queue/2" do
-    assert {:ok, %{body: %{queue_url: _}}} =
-             SQS.create_queue("another_queue2", receive_message_wait_time_seconds: 20)
+    queue_name = "test_queue_3"
+
+    assert {:ok, %{body: %{queue_url: queue_url}}} =
+             SQS.create_queue(queue_name, receive_message_wait_time_seconds: 20)
              |> ExAws.request()
+
+    assert queue_url |> String.contains?(queue_name)
   end
 
   test "delete_message/2", context do
-    assert {:ok, _} =
-             SQS.delete_message(
-               context.queue_url,
-               "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw=="
-             )
-             |> ExAws.request()
+    assert {:ok, %{body: %{request_id: _}}} =
+             SQS.delete_message(context.queue_url, "a_receipt_handle") |> ExAws.request()
   end
 
   test "delete_message_batch/2", context do
@@ -112,31 +119,29 @@ defmodule ExAws.SQSIntegrationTest do
              SQS.delete_message_batch(context.queue_url, [
                %{
                  id: "message_1",
-                 receipt_handle:
-                   "AQEBlA6/i+8F3P6lA7y3msc8dINnF+b3VgTX71nMWw7VvbHc8mdGFyZjVAVMH/rg6Vyc00O2Tl2ZyKn8IPUiy6n44ipop+xb33XNU/cABvVWZogNN95b9mmR6RuSA0dcVmFL02TwZDpg7cMOWNhYThEp+a5atsG85PX7V6q9zBklltBSQnT6r9QSngnv2m1C23jfFYow0oy86cofp0mQ4z5ez9bWmlHa4XfpZUpP2KVlBCDgyR0tQQRGt170foph32Cg+Bp6RRv9Tyo7aVWqM4OT/CHTJ0ZPiAYoH8MYFxjUaqoeKhUwDFq36trQxrBq9BfBj+hrzEtDQdxcNZM2pZi2xQ=="
+                 receipt_handle: "a_receipt_handle"
                },
                %{
                  id: "message_2",
-                 receipt_handle:
-                   "AQEBc8vuFKIpTF3ESXTpxc2+vARUXHpGzup9YwTMD7Alibe/z/yXEPaXY4ZtTUvInYfEazLhughdoLGSEh1SDPsIdDB9Os8D84xHmtXelswA7FBXEdNunRk4wg6Zi4jgjEy3Kyy9cGpiZwRxw4Vy4PrK7H0BbH07k+mVby8P8B9m97GO/w666/zU46QpFB6jhi7L0d76AW16/PMzEBbDB6zUvXiYUAMmxvdppYrcYqb22K0gWvZsL1Dogr592k/fA1W2oF1YsjTSn9FjYr/q5XK1Z1Lvvmh3/20D5U0qjnFd4wg9MlVp8zrBg2mNoVl6QEHPNP/zA+dZg2d/6SSgEdI1hQ=="
+                 receipt_handle: "another_receipt_handle"
                }
              ])
              |> ExAws.request()
   end
 
   test "delete_queue/1" do
-    {:ok, %{body: %{queue_url: queue_url}}} =
-      SQS.create_queue("another_test_queue") |> ExAws.request()
+    {:ok, %{body: %{queue_url: queue_url}}} = SQS.create_queue("test_queue_4") |> ExAws.request()
 
-    assert {:ok, _} = SQS.delete_queue(queue_url) |> ExAws.request()
+    assert {:ok, %{body: %{request_id: _}}} = SQS.delete_queue(queue_url) |> ExAws.request()
   end
 
   test "get_queue_attributes/1", context do
-    assert {:ok, _} = SQS.get_queue_attributes(context.queue_url) |> ExAws.request()
+    assert {:ok, %{body: %{attributes: _, request_id: _}}} =
+             SQS.get_queue_attributes(context.queue_url) |> ExAws.request()
   end
 
   test "get_queue_attributes/2", context do
-    assert {:ok, _} =
+    assert {:ok, %{body: %{attributes: _, request_id: _}}} =
              SQS.get_queue_attributes(context.queue_url, [
                :visibility_timeout,
                :message_retention_period
@@ -145,12 +150,17 @@ defmodule ExAws.SQSIntegrationTest do
   end
 
   test "get_queue_url/1" do
-    assert {:ok, %{body: %{queue_url: _}}} = SQS.get_queue_url(@queue_name) |> ExAws.request()
+    assert {:ok, %{body: %{queue_url: queue_url}}} =
+             SQS.get_queue_url(@queue_name) |> ExAws.request()
+
+    assert queue_url |> String.contains?(@queue_name)
   end
 
   test "get_queue_url/2" do
-    assert {:ok, %{body: %{queue_url: _}}} =
+    assert {:ok, %{body: %{queue_url: queue_url}}} =
              SQS.get_queue_url(@queue_name, queue_owner_aws_account_id: "foo") |> ExAws.request()
+
+    assert queue_url |> String.contains?(@queue_name)
   end
 
   @tag :skip
@@ -159,32 +169,41 @@ defmodule ExAws.SQSIntegrationTest do
   end
 
   test "list_queues/0" do
-    assert {:ok, %{body: %{queues: _}}} = SQS.list_queues() |> ExAws.request()
+    assert {:ok, %{body: %{queues: queues}}} = SQS.list_queues() |> ExAws.request()
+    assert is_list(queues)
   end
 
   test "list_queues/1" do
-    assert {:ok, %{body: %{queues: _}}} =
+    assert {:ok, %{body: %{queues: queues}}} =
              SQS.list_queues(queue_name_prefix: "prefix") |> ExAws.request()
+
+    assert is_list(queues)
   end
 
   @tag :skip
   test "list_queue_tags NOT IMPLEMENTED"
 
   test "purge_queue/1", context do
-    assert {:ok, _} = SQS.purge_queue(context.queue_url) |> ExAws.request()
+    assert {:ok, %{body: %{request_id: _}}} =
+             SQS.purge_queue(context.queue_url) |> ExAws.request()
   end
 
   test "receive_message/1", context do
-    assert {:ok, _} = SQS.receive_message(context.queue_url) |> ExAws.request()
+    assert {:ok, %{body: %{messages: messages}}} =
+             SQS.receive_message(context.queue_url) |> ExAws.request()
+
+    assert is_list(messages)
   end
 
   test "receive_message/2", context do
-    assert {:ok, _} =
+    assert {:ok, %{body: %{messages: messages}}} =
              SQS.receive_message(context.queue_url,
                attribute_names: :all,
                max_number_of_messages: 5
              )
              |> ExAws.request()
+
+    assert is_list(messages)
   end
 
   @tag :skip
@@ -196,11 +215,27 @@ defmodule ExAws.SQSIntegrationTest do
   end
 
   test "send_message/2", context do
-    assert {:ok, _} = SQS.send_message(context.queue_url, "lorem ipsum") |> ExAws.request()
+    assert {:ok,
+            %{
+              body: %{
+                md5_of_message_attributes: _,
+                md5_of_message_body: _,
+                message_id: _,
+                request_id: _
+              }
+            }} = SQS.send_message(context.queue_url, "lorem ipsum") |> ExAws.request()
   end
 
   test "send_message/3", context do
-    assert {:ok, _} =
+    assert {:ok,
+            %{
+              body: %{
+                md5_of_message_attributes: _,
+                md5_of_message_body: _,
+                message_id: _,
+                request_id: _
+              }
+            }} =
              SQS.send_message(
                context.queue_url,
                "This is the message body.",
@@ -217,44 +252,47 @@ defmodule ExAws.SQSIntegrationTest do
   end
 
   test "send_message_batch/2", context do
-    assert {:ok, _} =
-             SQS.send_message_batch(
-               context.queue_url,
-               [
-                 [
-                   id: "test_message_1",
-                   message_body: "This is the message body.",
-                   delay_seconds: 30,
-                   message_attributes: [
-                     %{
-                       name: "TestStringAttribute",
-                       data_type: :string,
-                       value: "testing!"
-                     }
-                   ]
-                 ],
-                 [
-                   id: "test_message_2",
-                   message_body: "This is the second message body.",
-                   message_attributes: [
-                     %{
-                       name: "TestAnotherStringAttribute",
-                       data_type: :string,
-                       value: "still testing!"
-                     }
-                   ]
-                 ]
-               ]
-             )
-             |> ExAws.request()
+    {:ok, %{body: %{failures: _, request_id: _, successes: successes}}} =
+      SQS.send_message_batch(
+        context.queue_url,
+        [
+          [
+            id: "test_message_1",
+            message_body: "This is the message body.",
+            delay_seconds: 30,
+            message_attributes: [
+              %{
+                name: "TestStringAttribute",
+                data_type: :string,
+                value: "testing!"
+              }
+            ]
+          ],
+          [
+            id: "test_message_2",
+            message_body: "This is the second message body.",
+            message_attributes: [
+              %{
+                name: "TestAnotherStringAttribute",
+                data_type: :string,
+                value: "still testing!"
+              }
+            ]
+          ]
+        ]
+      )
+      |> ExAws.request()
+
+    assert ["test_message_1", "test_message_2"] == successes |> Enum.map(& &1.id) |> Enum.sort()
   end
 
   test "set_queue_attributes/1", context do
-    assert {:ok, _} = SQS.set_queue_attributes(context.queue_url) |> ExAws.request()
+    assert {:ok, %{body: %{request_id: _}}} =
+             SQS.set_queue_attributes(context.queue_url) |> ExAws.request()
   end
 
   test "set_queue_attributes/2", context do
-    assert {:ok, _} =
+    assert {:ok, %{body: %{request_id: _}}} =
              SQS.set_queue_attributes(context.queue_url, visibility_timeout: 10)
              |> ExAws.request()
   end

--- a/test/lib/sqs/integration_test.exs
+++ b/test/lib/sqs/integration_test.exs
@@ -1,7 +1,267 @@
 defmodule ExAws.SQSIntegrationTest do
   use ExUnit.Case, async: true
+  alias ExAws.SQS
 
-  test "list_queues works" do
-    assert {:ok, %{body: %{queues: _}}} = ExAws.SQS.list_queues |> ExAws.request
+  @queue_name "test_queue"
+
+  setup_all do
+    ExAws.Config.new(:sqs)
+
+    {:ok, %{body: %{queue_url: queue_url}}} = SQS.create_queue(@queue_name) |> ExAws.request()
+
+    [queue_url: queue_url]
   end
+
+  test "add_permission/2" do
+    assert {:ok, _} = SQS.add_permission(@queue_name, "TestAddPermission") |> ExAws.request()
+  end
+
+  test "add_permission/3" do
+    assert {:ok, _} =
+             SQS.add_permission(@queue_name, "TestAddPermission2", %{
+               "681962096817" => :all,
+               "071669896281" => [:send_message, :receive_message]
+             })
+             |> ExAws.request()
+  end
+
+  test "change_message_visibility/3", context do
+    SQS.send_message(context.queue_url, "lorem ipsum") |> ExAws.request()
+
+    {:ok, %{body: %{messages: messages}}} =
+      SQS.receive_message(context.queue_url) |> ExAws.request()
+
+    receipt_handle = List.first(messages).receipt_handle
+
+    assert {:ok, _} =
+             SQS.change_message_visibility(context.queue_url, receipt_handle, 300)
+             |> ExAws.request()
+  end
+
+  test "change_message_visibility_batch/2", context do
+    SQS.send_message_batch(
+      context.queue_url,
+      [
+        [
+          id: "message_1",
+          message_body: "This is the first message body.",
+          message_attributes: [
+            %{
+              name: "TestAnotherStringAttribute",
+              data_type: :string,
+              value: "still testing!"
+            }
+          ]
+        ],
+        [
+          id: "message_2",
+          message_body: "This is the second message body.",
+          message_attributes: [
+            %{
+              name: "TestAnotherStringAttribute",
+              data_type: :string,
+              value: "still testing!"
+            }
+          ]
+        ]
+      ]
+    )
+    |> ExAws.request()
+
+    {:ok, %{body: %{messages: messages}}} =
+      SQS.receive_message(context.queue_url, attribute_names: :all, max_number_of_messages: 2)
+      |> ExAws.request()
+
+    messages_payload =
+      messages
+      |> Enum.map(fn message ->
+        %{
+          id: message.message_id,
+          receipt_handle: message.receipt_handle,
+          visibility_timeout: 600
+        }
+      end)
+
+    assert {:ok, _} =
+             SQS.change_message_visibility_batch(context.queue_url, messages_payload)
+             |> ExAws.request()
+  end
+
+  test "create_queue/1" do
+    assert {:ok, %{body: %{queue_url: _}}} =
+             SQS.create_queue("yet_another_test_queue") |> ExAws.request()
+  end
+
+  test "create_queue/2" do
+    assert {:ok, %{body: %{queue_url: _}}} =
+             SQS.create_queue("another_queue2", receive_message_wait_time_seconds: 20)
+             |> ExAws.request()
+  end
+
+  test "delete_message/2", context do
+    assert {:ok, _} =
+             SQS.delete_message(
+               context.queue_url,
+               "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw=="
+             )
+             |> ExAws.request()
+  end
+
+  test "delete_message_batch/2", context do
+    assert {:ok, _} =
+             SQS.delete_message_batch(context.queue_url, [
+               %{
+                 id: "message_1",
+                 receipt_handle:
+                   "AQEBlA6/i+8F3P6lA7y3msc8dINnF+b3VgTX71nMWw7VvbHc8mdGFyZjVAVMH/rg6Vyc00O2Tl2ZyKn8IPUiy6n44ipop+xb33XNU/cABvVWZogNN95b9mmR6RuSA0dcVmFL02TwZDpg7cMOWNhYThEp+a5atsG85PX7V6q9zBklltBSQnT6r9QSngnv2m1C23jfFYow0oy86cofp0mQ4z5ez9bWmlHa4XfpZUpP2KVlBCDgyR0tQQRGt170foph32Cg+Bp6RRv9Tyo7aVWqM4OT/CHTJ0ZPiAYoH8MYFxjUaqoeKhUwDFq36trQxrBq9BfBj+hrzEtDQdxcNZM2pZi2xQ=="
+               },
+               %{
+                 id: "message_2",
+                 receipt_handle:
+                   "AQEBc8vuFKIpTF3ESXTpxc2+vARUXHpGzup9YwTMD7Alibe/z/yXEPaXY4ZtTUvInYfEazLhughdoLGSEh1SDPsIdDB9Os8D84xHmtXelswA7FBXEdNunRk4wg6Zi4jgjEy3Kyy9cGpiZwRxw4Vy4PrK7H0BbH07k+mVby8P8B9m97GO/w666/zU46QpFB6jhi7L0d76AW16/PMzEBbDB6zUvXiYUAMmxvdppYrcYqb22K0gWvZsL1Dogr592k/fA1W2oF1YsjTSn9FjYr/q5XK1Z1Lvvmh3/20D5U0qjnFd4wg9MlVp8zrBg2mNoVl6QEHPNP/zA+dZg2d/6SSgEdI1hQ=="
+               }
+             ])
+             |> ExAws.request()
+  end
+
+  test "delete_queue/1" do
+    {:ok, %{body: %{queue_url: queue_url}}} =
+      SQS.create_queue("another_test_queue") |> ExAws.request()
+
+    assert {:ok, _} = SQS.delete_queue(queue_url) |> ExAws.request()
+  end
+
+  test "get_queue_attributes/1", context do
+    assert {:ok, _} = SQS.get_queue_attributes(context.queue_url) |> ExAws.request()
+  end
+
+  test "get_queue_attributes/2", context do
+    assert {:ok, _} =
+             SQS.get_queue_attributes(context.queue_url, [
+               :visibility_timeout,
+               :message_retention_period
+             ])
+             |> ExAws.request()
+  end
+
+  test "get_queue_url/1" do
+    assert {:ok, %{body: %{queue_url: _}}} = SQS.get_queue_url(@queue_name) |> ExAws.request()
+  end
+
+  test "get_queue_url/2" do
+    assert {:ok, %{body: %{queue_url: _}}} =
+             SQS.get_queue_url(@queue_name, queue_owner_aws_account_id: "foo") |> ExAws.request()
+  end
+
+  @tag :skip
+  test "list_dead_letter_source_queues/1", context do
+    assert {:ok, _} = SQS.list_dead_letter_source_queues(context.queue_url) |> ExAws.request()
+  end
+
+  test "list_queues/0" do
+    assert {:ok, %{body: %{queues: _}}} = SQS.list_queues() |> ExAws.request()
+  end
+
+  test "list_queues/1" do
+    assert {:ok, %{body: %{queues: _}}} =
+             SQS.list_queues(queue_name_prefix: "prefix") |> ExAws.request()
+  end
+
+  @tag :skip
+  test "list_queue_tags NOT IMPLEMENTED"
+
+  test "purge_queue/1", context do
+    assert {:ok, _} = SQS.purge_queue(context.queue_url) |> ExAws.request()
+  end
+
+  test "receive_message/1", context do
+    assert {:ok, _} = SQS.receive_message(context.queue_url) |> ExAws.request()
+  end
+
+  test "receive_message/2", context do
+    assert {:ok, _} =
+             SQS.receive_message(context.queue_url,
+               attribute_names: :all,
+               max_number_of_messages: 5
+             )
+             |> ExAws.request()
+  end
+
+  @tag :skip
+  test "remove_permission/2", context do
+    SQS.add_permission(@queue_name, "TestAddPermission") |> ExAws.request()
+
+    assert {:ok, _} =
+             SQS.remove_permission(context.queue_url, "TestAddPermission") |> ExAws.request()
+  end
+
+  test "send_message/2", context do
+    assert {:ok, _} = SQS.send_message(context.queue_url, "lorem ipsum") |> ExAws.request()
+  end
+
+  test "send_message/3", context do
+    assert {:ok, _} =
+             SQS.send_message(
+               context.queue_url,
+               "This is the message body.",
+               delay_seconds: 30,
+               message_attributes: [
+                 %{
+                   name: "TestStringAttribute",
+                   data_type: :string,
+                   value: "testing!"
+                 }
+               ]
+             )
+             |> ExAws.request()
+  end
+
+  test "send_message_batch/2", context do
+    assert {:ok, _} =
+             SQS.send_message_batch(
+               context.queue_url,
+               [
+                 [
+                   id: "test_message_1",
+                   message_body: "This is the message body.",
+                   delay_seconds: 30,
+                   message_attributes: [
+                     %{
+                       name: "TestStringAttribute",
+                       data_type: :string,
+                       value: "testing!"
+                     }
+                   ]
+                 ],
+                 [
+                   id: "test_message_2",
+                   message_body: "This is the second message body.",
+                   message_attributes: [
+                     %{
+                       name: "TestAnotherStringAttribute",
+                       data_type: :string,
+                       value: "still testing!"
+                     }
+                   ]
+                 ]
+               ]
+             )
+             |> ExAws.request()
+  end
+
+  test "set_queue_attributes/1", context do
+    assert {:ok, _} = SQS.set_queue_attributes(context.queue_url) |> ExAws.request()
+  end
+
+  test "set_queue_attributes/2", context do
+    assert {:ok, _} =
+             SQS.set_queue_attributes(context.queue_url, visibility_timeout: 10)
+             |> ExAws.request()
+  end
+
+  @tag :skip
+  test "tag_queue NOT IMPLEMENTED"
+
+  @tag :skip
+  test "untag_queue NOT IMPLEMENTED"
 end

--- a/test/lib/sqs_test.exs
+++ b/test/lib/sqs_test.exs
@@ -8,7 +8,7 @@ defmodule ExAws.SQSTest do
   end
 
   test "#delete_queue" do
-    expected = %{"Action" => "DeleteQueue"}
+    expected = %{"Action" => "DeleteQueue", "QueueUrl" => "982071696186/test_queue"}
     assert expected == SQS.delete_queue("982071696186/test_queue").params
   end
 
@@ -25,25 +25,25 @@ defmodule ExAws.SQSTest do
   end
 
   test "#get_queue_attributes" do
-    expected = %{"Action" => "GetQueueAttributes", "AttributeName.1" => "All"}
+    expected = %{"Action" => "GetQueueAttributes", "QueueUrl" => "982071696186/test_queue", "AttributeName.1" => "All"}
     assert expected == SQS.get_queue_attributes("982071696186/test_queue").params
 
-    expected =  %{"Action" => "GetQueueAttributes", "AttributeName.1" => "VisibilityTimeout", "AttributeName.2" => "MessageRetentionPeriod"}
+    expected =  %{"Action" => "GetQueueAttributes", "QueueUrl" => "982071696186/test_queue", "AttributeName.1" => "VisibilityTimeout", "AttributeName.2" => "MessageRetentionPeriod"}
     assert expected == SQS.get_queue_attributes("982071696186/test_queue", [:visibility_timeout, :message_retention_period]).params
   end
 
   test "#set_queue_attributes" do
-    expected = %{"Action" => "SetQueueAttributes", "Attribute.1.Name" => "VisibilityTimeout", "Attribute.1.Value" => 10}
+    expected = %{"Action" => "SetQueueAttributes", "QueueUrl" => "982071696186/test_queue", "Attribute.1.Name" => "VisibilityTimeout", "Attribute.1.Value" => 10}
     assert expected == SQS.set_queue_attributes("982071696186/test_queue", visibility_timeout: 10).params
   end
 
   test "#purge_queue" do
-    expected = %{"Action" => "PurgeQueue"}
+    expected = %{"Action" => "PurgeQueue", "QueueUrl" => "982071696186/test_queue"}
     assert expected == SQS.purge_queue("982071696186/test_queue").params
   end
 
   test "#list_dead_letter_source_queues" do
-    expected = %{"Action" => "ListDeadLetterSourceQueues"}
+    expected = %{"Action" => "ListDeadLetterSourceQueues", "QueueUrl" => "982071696186/test_queue"}
     assert expected == SQS.list_dead_letter_source_queues("982071696186/test_queue").params
   end
 
@@ -56,27 +56,29 @@ defmodule ExAws.SQSTest do
       "AWSAccountId.2" => "071669896281",
       "ActionName.2" => "SendMessage",
       "AWSAccountId.3" => "071669896281",
-      "ActionName.3" => "ReceiveMessage"
+      "ActionName.3" => "ReceiveMessage",
+      "QueueUrl" => "982071696186/test_queue"
     }
 
     assert expected == SQS.add_permission("982071696186/test_queue", "TestAddPermission", %{"681962096817" => :all, "071669896281" => [:send_message, :receive_message]}).params
   end
 
   test "#remove_permission" do
-    expected = %{"Action" => "RemovePermission", "Label" => "TestAddPermission"}
+    expected = %{"Action" => "RemovePermission", "Label" => "TestAddPermission", "QueueUrl" => "982071696186/test_queue"}
 
     assert expected == SQS.remove_permission("982071696186/test_queue", "TestAddPermission").params
   end
 
   test "#send_message" do
     expected = %{"Action" => "SendMessage",
+                 "QueueUrl" => "982071696186/test_queue",
                  "MessageBody" => "This is the message body.",
                  "DelaySeconds" => 30,
                  "MessageAttribute.1.Name" => "TestStringAttribute",
                  "MessageAttribute.1.Value.StringValue" => "testing!",
                  "MessageAttribute.1.Value.DataType" => "String",
                  "MessageAttribute.2.Name" => "TestBinaryAttribute",
-                 "MessageAttribute.2.Value.BinaryValue" => <<31, 139, 8, 0, 0, 0, 0, 0, 0, 19, 43, 73, 45, 46, 201, 204, 75, 87, 4, 0, 188, 169, 224, 119, 8, 0, 0, 0>>,
+                 "MessageAttribute.2.Value.BinaryValue" => :zlib.gzip("testing!"),
                  "MessageAttribute.2.Value.DataType" => "Binary",
                  "MessageAttribute.3.Name" => "TestNumberAttribute",
                  "MessageAttribute.3.Value.StringValue" => 42,
@@ -119,6 +121,7 @@ defmodule ExAws.SQSTest do
 
   test "#send_message for FIFO queue" do
     expected = %{"Action" => "SendMessage",
+                 "QueueUrl" => "982071696186/test_queue",
                  "MessageBody" => "This is the message body.",
                  "DelaySeconds" => 30,
                  "MessageAttribute.1.Name" => "TestStringAttribute",
@@ -147,6 +150,7 @@ defmodule ExAws.SQSTest do
 
   test "#send_message_batch" do
     expected = %{"Action" => "SendMessageBatch",
+                 "QueueUrl" => "982071696186/test_queue",
                  "SendMessageBatchRequestEntry.1.Id" => "test_message_1",
                  "SendMessageBatchRequestEntry.1.MessageBody" => "This is the message body.",
                  "SendMessageBatchRequestEntry.1.DelaySeconds" => 30,
@@ -154,7 +158,7 @@ defmodule ExAws.SQSTest do
                  "SendMessageBatchRequestEntry.1.MessageAttribute.1.Value.StringValue" => "testing!",
                  "SendMessageBatchRequestEntry.1.MessageAttribute.1.Value.DataType" => "String",
                  "SendMessageBatchRequestEntry.1.MessageAttribute.2.Name" => "TestBinaryAttribute",
-                 "SendMessageBatchRequestEntry.1.MessageAttribute.2.Value.BinaryValue" => <<31, 139, 8, 0, 0, 0, 0, 0, 0, 19, 43, 73, 45, 46, 201, 204, 75, 87, 4, 0, 188, 169, 224, 119, 8, 0, 0, 0>>,
+                 "SendMessageBatchRequestEntry.1.MessageAttribute.2.Value.BinaryValue" => :zlib.gzip("testing!"),
                  "SendMessageBatchRequestEntry.1.MessageAttribute.2.Value.DataType" => "Binary",
                  "SendMessageBatchRequestEntry.1.MessageAttribute.3.Name" => "TestNumberAttribute",
                  "SendMessageBatchRequestEntry.1.MessageAttribute.3.Value.StringValue" => 42,
@@ -217,6 +221,7 @@ defmodule ExAws.SQSTest do
 
   test "#send_message_batch for FIFO queue" do
     expected = %{"Action" => "SendMessageBatch",
+                 "QueueUrl" => "982071696186/test_queue.fifo",
                  "SendMessageBatchRequestEntry.1.Id" => "test_message_1",
                  "SendMessageBatchRequestEntry.1.MessageBody" => "This is the message body.",
                  "SendMessageBatchRequestEntry.1.DelaySeconds" => 30,
@@ -269,21 +274,21 @@ defmodule ExAws.SQSTest do
   end
 
   test "#receive_message" do
-    expected = %{"Action" => "ReceiveMessage"}
+    expected = %{"Action" => "ReceiveMessage", "QueueUrl" => "982071696186/test_queue"}
     assert expected == SQS.receive_message("982071696186/test_queue").params
 
-    expected = %{"Action" => "ReceiveMessage", "AttributeName.1" => "All", "MaxNumberOfMessages" => 5}
+    expected = %{"Action" => "ReceiveMessage", "AttributeName.1" => "All", "MaxNumberOfMessages" => 5, "QueueUrl" => "982071696186/test_queue"}
     assert expected == SQS.receive_message("982071696186/test_queue", attribute_names: :all,
                                                                       max_number_of_messages: 5).params
 
-    expected = %{"Action" => "ReceiveMessage", "AttributeName.1" => "SenderId", "AttributeName.2" => "ApproximateReceiveCount", "VisibilityTimeout" => 1000, "WaitTimeSeconds" => 20}
+    expected = %{"Action" => "ReceiveMessage", "AttributeName.1" => "SenderId", "AttributeName.2" => "ApproximateReceiveCount", "VisibilityTimeout" => 1000, "WaitTimeSeconds" => 20, "QueueUrl" => "982071696186/test_queue"}
     assert expected == SQS.receive_message("982071696186/test_queue", attribute_names: [:sender_id, :approximate_receive_count],
                                                                       visibility_timeout: 1000,
                                                                       wait_time_seconds: 20).params
   end
 
   test "#receive_message can set the message attributes to all" do
-    expected = %{"Action" => "ReceiveMessage", "MessageAttributeNames" => "All"}
+    expected = %{"Action" => "ReceiveMessage", "QueueUrl" => "12345/test_queue", "MessageAttributeNames" => "All"}
 
     actual = SQS.receive_message("12345/test_queue", message_attribute_names: :all)
     assert expected == actual.params
@@ -291,6 +296,7 @@ defmodule ExAws.SQSTest do
 
   test "#receive_message can specify message attributes" do
     expected = %{"Action" => "ReceiveMessage",
+                 "QueueUrl" => "12345/test_queue",
                  "MessageAttributeName.1" => "FooAttr",
                  "MessageAttributeName.2" => "BarAttr",
                  "MessageAttributeName.3" => "BazAttr"}
@@ -302,6 +308,7 @@ defmodule ExAws.SQSTest do
 
   test "#receive_message can specify wildcard attributes" do
     expected = %{"Action" => "ReceiveMessage",
+                 "QueueUrl" => "12345/test_queue",
                  "MessageAttributeName.1" => "Foo.*"}
     actual = SQS.receive_message("12345/test_queue",
                                  message_attribute_names: ["Foo.*"])
@@ -310,6 +317,7 @@ defmodule ExAws.SQSTest do
 
   test "receive_message can set atom message attributes" do
     expected = %{"Action" => "ReceiveMessage",
+                 "QueueUrl" => "12345/test_queue",
                  "MessageAttributeName.1" => "FooAttr",
                  "MessageAttributeName.2" => "BarAttr",
                  "MessageAttributeName.3" => "BazAttr"}
@@ -320,12 +328,13 @@ defmodule ExAws.SQSTest do
   end
 
   test "#delete_message" do
-    expected = %{"Action" => "DeleteMessage", "ReceiptHandle" => "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw=="}
+    expected = %{"Action" => "DeleteMessage", "QueueUrl" => "982071696186/test_queue", "ReceiptHandle" => "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw=="}
     assert expected == SQS.delete_message("982071696186/test_queue", "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw==").params
   end
 
   test "#delete_message_batch" do
     expected = %{"Action" => "DeleteMessageBatch",
+                 "QueueUrl" => "982071696186/test_queue",
                  "DeleteMessageBatchRequestEntry.1.Id" => "message_1",
                  "DeleteMessageBatchRequestEntry.1.ReceiptHandle" => "AQEBlA6/i+8F3P6lA7y3msc8dINnF+b3VgTX71nMWw7VvbHc8mdGFyZjVAVMH/rg6Vyc00O2Tl2ZyKn8IPUiy6n44ipop+xb33XNU/cABvVWZogNN95b9mmR6RuSA0dcVmFL02TwZDpg7cMOWNhYThEp+a5atsG85PX7V6q9zBklltBSQnT6r9QSngnv2m1C23jfFYow0oy86cofp0mQ4z5ez9bWmlHa4XfpZUpP2KVlBCDgyR0tQQRGt170foph32Cg+Bp6RRv9Tyo7aVWqM4OT/CHTJ0ZPiAYoH8MYFxjUaqoeKhUwDFq36trQxrBq9BfBj+hrzEtDQdxcNZM2pZi2xQ==",
                  "DeleteMessageBatchRequestEntry.2.Id" => "message_2",
@@ -345,6 +354,7 @@ defmodule ExAws.SQSTest do
 
   test "#change_message_visibility" do
     expected = %{"Action" => "ChangeMessageVisibility",
+                 "QueueUrl" => "982071696186/test_queue",
                  "ReceiptHandle" => "AQEBS52UqQL7wJo1I21OqVBXTbxZa0WrHqKntw/N4YtYblV3mix7BkEQVM16K9WABAM9q6AKqjiuTPQAmhqRz2+pw02QuNB5kUn2hpSLVTasAkcTMPgFfLFEufBxGR2hxGeOvP/XDO3DPGnQO3WvOSJTxQKitwT9xWDWAZgm96Ra1pnduckZkLTWolj+34okJqQTDVAL7/Br4BEtgHQXJKm5BCfry8jA1XYjy5IjyB2syLihdgVU0qBLxlGDDhuCOW5eNQiVig3v0oa7SVvRKzMK4bMor1Y17wSETo6y0gYb1QtD1rBUpoKAeq49gpKjBnAkMdHV/DFAfRAtcJNcsPpiQA==",
                  "VisibilityTimeout" => 300}
 
@@ -355,6 +365,7 @@ defmodule ExAws.SQSTest do
 
   test "#change_message_visibility_batch" do
     expected = %{"Action" => "ChangeMessageVisibilityBatch",
+                 "QueueUrl" => "982071696186/test_queue",
                  "ChangeMessageVisibilityBatchRequestEntry.1.Id" => "message_1",
                  "ChangeMessageVisibilityBatchRequestEntry.1.ReceiptHandle" => "AQEBnLhpyRJrHQrnrj9KdMD2PjD5XJdb26X12vvOvZuqoa/i1LGSq4JO7HHmoXGbrn04Zi4jTb4yQGywI/Q1yah/kPgLQuiOAHlnPvypRmKeToeJoHA75bduoC0o8rCokcQtTy9ZGIBM/WlnrND4Cs0Zie7KJEEq4LxDb9xivphZp1vjXTwActAwCN6jk4rSlyXaLTgYoeeugjm4RoM0Vq+iSQX/vksNAkEy2pjZWg3/K8v8/2JQZtop6F6JjcaRlhRYSKvwSu0Xjh3U3QJhXaWZL0u9e08k16g8pE5Q/5s50Gjo9qTkDFUdJVBmFdiyccH1afkkwgYQ4/TJ9j/wR2jQRA==",
                  "ChangeMessageVisibilityBatchRequestEntry.1.VisibilityTimeout" => 300,
@@ -376,7 +387,7 @@ defmodule ExAws.SQSTest do
       }
     ])
 
-    assert result.path == "/982071696186/test_queue"
+    assert result.path == "/"
     assert result.params == expected
   end
 end


### PR DESCRIPTION
As stated in the [AWS SQS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-general-identifiers.html#queue-name-url)
    
> In your system, always store the entire queue URL exactly as Amazon SQS returns it to you when you create the queue
> Don't build the queue URL from its separate components each time you need to specify
> the queue URL in a request because Amazon SQS can change the components that make up the queue URL.
    
For more information see: https://github.com/ex-aws/ex_aws_sqs/issues/8#issue-431553315
    
This PR should ease the integration with [ElasticMQ](https://github.com/softwaremill/elasticmq) and [LocalStack](https://github.com/localstack/localstack)
    
Fixes #8

You can see the tests running in Travis with ElasticMQ here: https://travis-ci.org/manelli/ex_aws_sqs