### PR TITLE
Typespec all allowed values for `sqs_message_attribute_name`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Elixir Language Server files (e.g. for VSCode users).
+/.elixir_ls

--- a/lib/ex_aws/sqs.ex
+++ b/lib/ex_aws/sqs.ex
@@ -10,13 +10,22 @@ defmodule ExAws.SQS do
     :change_message_visibility |
     :get_queue_attributes
   @type sqs_acl :: %{ binary => :all | [sqs_permission, ...]}
+
+  # Values taken from
+  # https://github.com/aws/aws-sdk-go/blob/075b1d697ba8dbab8bb841042fa12d43192d0153/models/apis/sqs/2012-11-05/api-2.json#L752.
+  # They differ from the list of allowed values described in the aws-cli (`aws sqs receive-message help`) or on
+  # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html, but they match the
+  # ones described in prose under the respective section.
   @type sqs_message_attribute_name ::
     :sender_id |
     :sent_timestamp |
     :approximate_receive_count |
     :approximate_first_receive_timestamp |
-    :wait_time_seconds |
-    :receive_message_wait_time_seconds
+    :sequence_number |
+    :message_deduplication_id |
+    :message_group_id |
+    :aws_trace_header
+
   @type sqs_queue_attribute_name ::
     :policy
     | :visibility_timeout
@@ -329,6 +338,7 @@ defmodule ExAws.SQS do
   end
 
   defp format_param_key("*"), do: "*"
+  defp format_param_key(:aws_trace_header), do: "AWSTraceHeader" # Key doesn't follow generic camelizing rule below.
   defp format_param_key(key) do
     key
     |> Atom.to_string

--- a/test/lib/sqs_test.exs
+++ b/test/lib/sqs_test.exs
@@ -281,8 +281,24 @@ defmodule ExAws.SQSTest do
     assert expected == SQS.receive_message("982071696186/test_queue", attribute_names: :all,
                                                                       max_number_of_messages: 5).params
 
-    expected = %{"Action" => "ReceiveMessage", "AttributeName.1" => "SenderId", "AttributeName.2" => "ApproximateReceiveCount", "VisibilityTimeout" => 1000, "WaitTimeSeconds" => 20, "QueueUrl" => "982071696186/test_queue"}
-    assert expected == SQS.receive_message("982071696186/test_queue", attribute_names: [:sender_id, :approximate_receive_count],
+    expected = %{
+      "Action" => "ReceiveMessage",
+      "AttributeName.1" => "SenderId",
+      "AttributeName.2" => "ApproximateReceiveCount",
+      "AttributeName.3" => "MessageDeduplicationId",
+      "AttributeName.4" => "MessageGroupId",
+      "AttributeName.5" => "AWSTraceHeader",
+      "VisibilityTimeout" => 1000,
+      "WaitTimeSeconds" => 20,
+      "QueueUrl" => "982071696186/test_queue"
+    }
+    assert expected == SQS.receive_message("982071696186/test_queue", attribute_names: [
+                                                                        :sender_id,
+                                                                        :approximate_receive_count,
+                                                                        :message_deduplication_id,
+                                                                        :message_group_id,
+                                                                        :aws_trace_header
+                                                                      ],
                                                                       visibility_timeout: 1000,
                                                                       wait_time_seconds: 20).params
   end


### PR DESCRIPTION
Hi & thanks for taking your time to create and maintain this project.

This pull request straightens out the values of `sqs_message_attribute_name` which are used when retrieving messages from SQS. Currently, only some of the attributes described on https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html#API_ReceiveMessage_RequestParameters are "available" as per typespec. This probably already created some confusion as seen in #13. 

For the `AWSTraceHeader` key, a special rule was introduced because the default camelization rule doesn't work here.

I have also removed two keys (`:wait_time_seconds` and `:receive_message_wait_time_seconds`) since they do not exist in the documentation and are also not included in the SQS response if `:all` is used... Please tell me your opinion on whether we can simply remove those keys or not. 