### PR TITLE
fix: parse message group id as string

### DIFF
--- a/lib/ex_aws/sqs/saxy_parser.ex
+++ b/lib/ex_aws/sqs/saxy_parser.ex
@@ -90,7 +90,7 @@ if Code.ensure_loaded?(Saxy) do
                               "Attribute",
                               :many,
                               name: ["Name"],
-                              value: ["Value", &__MODULE__.try_cast/1]
+                              value: ["Value"]
                             ]
                           )
 
@@ -159,7 +159,7 @@ if Code.ensure_loaded?(Saxy) do
                            "Attribute",
                            :many,
                            name: ["Name"],
-                           value: ["Value", &__MODULE__.try_cast/1]
+                           value: ["Value"]
                          ],
                          message_attributes: [
                            "MessageAttribute",
@@ -337,19 +337,27 @@ if Code.ensure_loaded?(Saxy) do
             attribute_name
           end
 
-        Map.put(acc, attribute_name, val)
+        parsed_val = try_cast(attribute_name, val)
+
+        Map.put(acc, attribute_name, parsed_val)
       end)
     end
 
-    def try_cast("true"), do: true
-    def try_cast("false"), do: false
+    def try_cast(_name, "true"), do: true
+    def try_cast(_name, "false"), do: false
 
-    def try_cast(string_val) do
-      try do
-        String.to_integer(string_val)
-      rescue
-        ArgumentError ->
+    def try_cast(name, string_val) do
+      case name do
+        "message_group_id" ->
           string_val
+
+        _ ->
+          try do
+            String.to_integer(string_val)
+          rescue
+            ArgumentError ->
+              string_val
+          end
       end
     end
   end

--- a/lib/ex_aws/sqs/sweet_xml_parser.ex
+++ b/lib/ex_aws/sqs/sweet_xml_parser.ex
@@ -74,7 +74,7 @@ if Code.ensure_loaded?(SweetXml) do
           attributes: [
             ~x"./GetQueueAttributesResult/Attribute"l,
             name: ~x"./Name/text()"s,
-            value: ~x"./Value/text()"s |> SweetXml.transform_by(&try_cast/1)
+            value: ~x"./Value/text()"s
           ],
           request_id: request_id_xpath()
         )
@@ -133,7 +133,7 @@ if Code.ensure_loaded?(SweetXml) do
             attributes: [
               ~x"./Attribute"lo,
               name: ~x"./Name/text()"s,
-              value: ~x"./Value/text()"s |> SweetXml.transform_by(&try_cast/1)
+              value: ~x"./Value/text()"s
             ],
             message_attributes: [
               ~x"./MessageAttribute"lo,
@@ -299,19 +299,27 @@ if Code.ensure_loaded?(SweetXml) do
             attribute_name
           end
 
-        Map.put(acc, attribute_name, val)
+        parsed_val = try_cast(attribute_name, val)
+
+        Map.put(acc, attribute_name, parsed_val)
       end)
     end
 
-    defp try_cast("true"), do: true
-    defp try_cast("false"), do: false
+    def try_cast(_name, "true"), do: true
+    def try_cast(_name, "false"), do: false
 
-    defp try_cast(string_val) do
-      try do
-        String.to_integer(string_val)
-      rescue
-        ArgumentError ->
+    def try_cast(name, string_val) do
+      case name do
+        "message_group_id" ->
           string_val
+
+        _ ->
+          try do
+            String.to_integer(string_val)
+          rescue
+            ArgumentError ->
+              string_val
+          end
       end
     end
 

--- a/test/lib/sqs/parser_test.exs
+++ b/test/lib/sqs/parser_test.exs
@@ -510,6 +510,58 @@ defmodule ExAws.SQS.ParserTest do
                } == message_attributes["UnknownVal"]
       end
 
+      test "parsing a fifo receive message response" do
+        rsp =
+          """
+          <ReceiveMessageResponse>
+            <ReceiveMessageResult>
+              <Message>
+                <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+                <ReceiptHandle>MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=</ReceiptHandle>
+                <MD5OfBody>fafb00f5732ab283681e124bf8747ed1</MD5OfBody>
+                <Body>This is a test message</Body>
+                <Attribute>
+                  <Name>SenderId</Name>
+                  <Value>195004372649</Value>
+                </Attribute>
+                <Attribute>
+                  <Name>SentTimestamp</Name>
+                  <Value>1238099229000</Value>
+                </Attribute>
+                <Attribute>
+                  <Name>ApproximateReceiveCount</Name>
+                  <Value>5</Value>
+                </Attribute>
+                <Attribute>
+                  <Name>ApproximateFirstReceiveTimestamp</Name>
+                  <Value>1250700979248</Value>
+                </Attribute>
+                <Attribute>
+                  <Name>MessageGroupId</Name>
+                  <Value>00111</Value>
+                </Attribute>
+                <Attribute>
+                  <Name>SequenceNumber</Name>
+                  <Value>1234567</Value>
+                </Attribute>
+              </Message>
+            </ReceiveMessageResult>
+            <ResponseMetadata>
+              <RequestId>b6633655-283d-45b4-aee4-4e84e0ae6afa</RequestId>
+            </ResponseMetadata>
+          </ReceiveMessageResponse>
+          """
+          |> to_success
+
+        {:ok, %{body: response}} = @parser.parse(rsp, :receive_message)
+        [message] = response[:messages]
+
+        attributes = message[:attributes]
+
+        assert "00111" == attributes["message_group_id"]
+        assert 1_234_567 == attributes["sequence_number"]
+      end
+
       test "handling a remove permission response" do
         rsp =
           """

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
-# Exclude all external tests from running  
+Application.ensure_all_started(:hackney)
+
+# Exclude all external tests from running
 ExUnit.configure(exclude: [external: true])
 
 ExUnit.start()


### PR DESCRIPTION
moved attribute value parsing into `attribute_list_to_map/2` so we have
the attribute name available. this allowed custom handling for certain
attributes, specifically to not parse `message_group_id` as a number.

fixes #24 

cc: @davidrusu