### PR TITLE
Fix `sqs_message_attribute` typing

### DIFF
--- a/lib/ex_aws/sqs.ex
+++ b/lib/ex_aws/sqs.ex
@@ -65,7 +65,7 @@ defmodule ExAws.SQS do
   @type sqs_message_attribute :: %{
           :name => binary,
           :data_type => :string | :binary | :number,
-          :custom_type => binary | none,
+          optional(:custom_type) => binary,
           :value => binary | number
         }
 


### PR DESCRIPTION
This PR fixes a dialyzer error when using `message_attributes` without the `custom_type` field.

The current typing results in a dialyzer error when using
```elixir
    ExAws.SQS.send_message(sqs_url, body,
      message_attributes: [
        %{name: "name", data_type: :string, value: "value"}
     ]
    )
```
due to `custom_type` not being marked as an optional field o `sqs_message_attribute` type.